### PR TITLE
feat(HTTP Client) - allow "extra" conf parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Authorized parameters for the export request are:
 - `format`: format expected for the export file (eg: "csv", "xls")
 - `export`: data type for your export (eg: 'pickup', 'producer', ...)
 - `search`: array of filters you want to apply for data included in your export file
+- `extra`: array of data that you want to use or pass throughout all the export process (e.g. an email to notify on success)
 
 No other configuration parameters are considered valid.  
 Once the export file has been requested on Airflow, the bundle uses a [Scheduler](https://symfony.com/doc/current/scheduler.html) recurring message to check every 30 seconds if the file has been successfully created, with its own handler.

--- a/src/Airflow/DagRunOutput.php
+++ b/src/Airflow/DagRunOutput.php
@@ -13,6 +13,8 @@ final class DagRunOutput
     public readonly string $executionDate;
     /** @var array<string> $conf */
     public readonly array $conf;
+    /** @var array<string> $extraData */
+    public readonly array $extraData;
 
     /**
      * @param array{
@@ -23,8 +25,9 @@ final class DagRunOutput
      *     execution_date?: string,
      *     conf?: array<string>
      *         } $airflowDagRunData
+     * @param array<string> $extraData
      */
-    public function __construct(array $airflowDagRunData)
+    public function __construct(array $airflowDagRunData, array $extraData = [])
     {
         $this->dagIdentifier = $airflowDagRunData['dag_id'] ?? '';
         $this->dagRunIdentifier = $airflowDagRunData['dag_run_id'] ?? '';
@@ -32,5 +35,6 @@ final class DagRunOutput
         $this->externalTrigger = $airflowDagRunData['external_trigger'] ?? false;
         $this->executionDate = $airflowDagRunData['execution_date'] ?? '';
         $this->conf = $airflowDagRunData['conf'] ?? [];
+        $this->extraData = $extraData;
     }
 }

--- a/src/Contracts/HttpClient/AirflowClientInterface.php
+++ b/src/Contracts/HttpClient/AirflowClientInterface.php
@@ -9,7 +9,7 @@ use Bluspark\AirflowDagRunBundle\Airflow\DagRunOutput;
 interface AirflowClientInterface
 {
     /**
-     * @param array{format?: string, export?: string, search?: array<string>} $parameters
+     * @param array{format?: string, export?: string, search?: array<string>, extra?: array<string>} $parameters
      */
     public function triggerNewDagRun(array $parameters): DagRunOutput;
 

--- a/src/HttpClient/AirflowClient.php
+++ b/src/HttpClient/AirflowClient.php
@@ -34,7 +34,7 @@ final class AirflowClient implements AirflowClientInterface
             ]
         )->toArray();
 
-        return new DagRunOutput($airflowData);
+        return new DagRunOutput($airflowData, $parameters['extra'] ?? []);
     }
 
     public function getDagRun(string $dagRunIdentifier): DagRunOutput

--- a/src/HttpClient/AirflowClient.php
+++ b/src/HttpClient/AirflowClient.php
@@ -25,6 +25,9 @@ final class AirflowClient implements AirflowClientInterface
         ]);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function triggerNewDagRun(array $parameters): DagRunOutput
     {
         $airflowData = $this->airflowClient->request(

--- a/src/Scheduler/Handler/DagRunCheckerHandler.php
+++ b/src/Scheduler/Handler/DagRunCheckerHandler.php
@@ -32,8 +32,6 @@ final class DagRunCheckerHandler
         }
 
         $dagRunChecker->setExecuted(true);
-        /** @var \DateTimeImmutable $executionDate */
-        $executionDate = \DateTimeImmutable::createFromFormat(DATE_ATOM, $dagRun->executionDate);
         $filename = sprintf('%s.%s', $dagRun->dagRunIdentifier, $dagRun->conf['format']);
 
         $this->messageBus->dispatch(new DagRunMessageExecuted($filename));

--- a/src/Validator/AirflowValidator.php
+++ b/src/Validator/AirflowValidator.php
@@ -8,7 +8,7 @@ use Bluspark\AirflowDagRunBundle\Contracts\Validator\AirflowValidatorInterface;
 
 class AirflowValidator implements AirflowValidatorInterface
 {
-    private const ALLOWED_PARAMETERS = ['format', 'export', 'search'];
+    private const ALLOWED_PARAMETERS = ['format', 'export', 'search', 'extra'];
 
     /**
      * {@inheritDoc}

--- a/src/Validator/AirflowValidator.php
+++ b/src/Validator/AirflowValidator.php
@@ -20,6 +20,9 @@ class AirflowValidator implements AirflowValidatorInterface
         return \count($diff) === 0;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getErrorMessage(array $parameterKeys): string
     {
         $diff = \array_diff($parameterKeys, self::ALLOWED_PARAMETERS);


### PR DESCRIPTION
Allow `extra` parameter to be include in given export parameters, so it can be passed to the `DagRunOutput` DTO.
This can be used for example when we want to pass an email to notify once export has been successfully generated by Airflow